### PR TITLE
Serve frontend index at root

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,15 +1,22 @@
 package main
 
 import (
-    "net/http"
-    "github.com/go-chi/chi/v5"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
 )
 
 func main() {
-    r := chi.NewRouter()
-    r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-        w.Write([]byte("Expense Tracker API"))
-    })
+	r := chi.NewRouter()
 
-    http.ListenAndServe(":8080", r)
+	// Serve the frontend index.html when the root path is requested
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "./frontend/index.html")
+	})
+
+	// Serve static frontend assets such as app.js and component files
+	fileServer := http.FileServer(http.Dir("./frontend"))
+	r.Handle("/*", http.StripPrefix("/", fileServer))
+
+	http.ListenAndServe(":8080", r)
 }


### PR DESCRIPTION
## Summary
- serve `frontend/index.html` on the root route
- expose other frontend assets through the Go backend

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*
- `go build ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841bda4a9588328bda71d9876274249