### PR TITLE
Add group metadata and merge master

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -4,7 +4,7 @@ name: Fly Deploy
 on:
   push:
     branches:
-      - main
+      - master
 jobs:
   deploy:
     name: Deploy app

--- a/db.go
+++ b/db.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// initDB opens the SQLite database and ensures required tables exist.
+func initDB(path string) *sql.DB {
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS groups (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        phone_numbers TEXT NOT NULL,
+        name TEXT NOT NULL,
+        created_by TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        default_currency TEXT
+    )`); err != nil {
+		log.Fatalf("create table: %v", err)
+	}
+
+	return db
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/kjhnns/expense-tracker-pwa
 
 go 1.23.0
 
-require github.com/go-chi/chi/v5 v5.2.1
+require (
+    github.com/go-chi/chi/v5 v5.2.1
+    github.com/mattn/go-sqlite3 v1.14.21
+)

--- a/groups.go
+++ b/groups.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// Group represents a collection of phone numbers.
+type Group struct {
+	ID              int64     `json:"id"`
+	Phones          []string  `json:"phones"`
+	Name            string    `json:"name"`
+	CreatedBy       string    `json:"created_by"`
+	CreatedAt       time.Time `json:"created_at"`
+	DefaultCurrency string    `json:"default_currency"`
+}
+
+type createGroupRequest struct {
+	Phones          []string `json:"phones"`
+	Name            string   `json:"name"`
+	CreatedBy       string   `json:"created_by"`
+	DefaultCurrency string   `json:"default_currency"`
+}
+
+// createGroupHandler saves a new group with phone numbers to the database.
+func createGroupHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req createGroupRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+		phonesJSON, err := json.Marshal(req.Phones)
+		if err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		stmt, err := db.Prepare(`INSERT INTO groups(phone_numbers, name, created_by, default_currency) VALUES(?,?,?,?)`)
+		if err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		defer stmt.Close()
+
+		res, err := stmt.Exec(string(phonesJSON), req.Name, req.CreatedBy, req.DefaultCurrency)
+		if err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		var createdAt time.Time
+		err = db.QueryRow(`SELECT created_at FROM groups WHERE id = ?`, id).Scan(&createdAt)
+		if err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(Group{
+			ID:              id,
+			Phones:          req.Phones,
+			Name:            req.Name,
+			CreatedBy:       req.CreatedBy,
+			CreatedAt:       createdAt,
+			DefaultCurrency: req.DefaultCurrency,
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,15 +1,28 @@
 package main
 
 import (
-    "net/http"
-    "github.com/go-chi/chi/v5"
+	"log"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
 )
 
 func main() {
-    r := chi.NewRouter()
-    r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-        w.Write([]byte("Expense Tracker API"))
-    })
+	db := initDB("data.db")
+	defer db.Close()
 
-    http.ListenAndServe(":8080", r)
+	r := chi.NewRouter()
+
+	// Serve the frontend index.html when the root path is requested
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "./frontend/index.html")
+	})
+
+	// Serve static frontend assets such as app.js and component files
+	fileServer := http.FileServer(http.Dir("./frontend"))
+	r.Handle("/*", http.StripPrefix("/", fileServer))
+
+	r.Post("/api/groups", createGroupHandler(db))
+
+	log.Fatal(http.ListenAndServe(":8080", r))
 }


### PR DESCRIPTION
## Summary
- merge latest changes from master
- serve frontend index with additional API route
- add metadata fields to group schema in SQLite
- update group creation handler to store metadata

## Testing
- `go build ./...` *(fails: Get "https://proxy.golang.org/github.com/go-chi/chi/v5/@v/v5.2.1.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841bded22d48328ad4492fc575d4f05