### PR TITLE
Add initial schema and group creation endpoint

### DIFF
--- a/db.go
+++ b/db.go
@@ -14,15 +14,36 @@ func initDB(path string) *sql.DB {
 		log.Fatalf("open db: %v", err)
 	}
 
-	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS groups (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        phone_numbers TEXT NOT NULL,
+	schema := `CREATE TABLE IF NOT EXISTS users (
+        phone_number TEXT PRIMARY KEY,
+        verified BOOLEAN NOT NULL DEFAULT 0,
+        display_name TEXT,
+        email TEXT,
+        notify_by_sms BOOLEAN NOT NULL DEFAULT 1,
+        notify_by_email BOOLEAN NOT NULL DEFAULT 1,
+        payment_methods TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS groups (
+        id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
-        created_by TEXT,
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        default_currency TEXT
-    )`); err != nil {
-		log.Fatalf("create table: %v", err)
+        created_by TEXT NOT NULL REFERENCES users(phone_number),
+        default_currency TEXT NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS group_members (
+        group_id TEXT NOT NULL REFERENCES groups(id),
+        phone_number TEXT NOT NULL REFERENCES users(phone_number),
+        display_name_override TEXT,
+        PRIMARY KEY (group_id, phone_number)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_group_members_group_id ON group_members(group_id);
+    CREATE INDEX IF NOT EXISTS idx_group_members_phone_number ON group_members(phone_number);`
+
+	if _, err := db.Exec(schema); err != nil {
+		log.Fatalf("create tables: %v", err)
 	}
 
 	return db

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kjhnns/expense-tracker-pwa
 go 1.23.0
 
 require (
-	github.com/go-chi/chi/v5 v5.2.1
-	github.com/mattn/go-sqlite3 v1.14.21
+        github.com/go-chi/chi/v5 v5.2.1
+        github.com/google/uuid v1.6.0
+        github.com/mattn/go-sqlite3 v1.14.21
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-sqlite3 v1.14.21 h1:IXocQLOykluc3xPE0Lvy8FtggMz1G+U3mEjg+0zGizc=
 github.com/mattn/go-sqlite3 v1.14.21/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/group_create.go
+++ b/group_create.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// createGroupRequestV2 is the expected payload for /groups/create
+// It mirrors the product requirements document.
+type createGroupRequestV2 struct {
+	GroupName       string   `json:"group_name"`
+	DefaultCurrency string   `json:"default_currency"`
+	CreatedBy       string   `json:"created_by"`
+	Participants    []string `json:"participants"`
+}
+
+type createGroupResponse struct {
+	GroupID     string            `json:"group_id"`
+	InviteLinks map[string]string `json:"invite_links"`
+}
+
+// createGroupEndpoint creates a new group and adds participants.
+func createGroupEndpoint(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req createGroupRequestV2
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		defer tx.Rollback()
+
+		groupID := uuid.New().String()
+		if _, err := tx.Exec(`INSERT INTO groups(id, name, created_by, default_currency) VALUES(?,?,?,?)`,
+			groupID, req.GroupName, req.CreatedBy, req.DefaultCurrency); err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		inviteLinks := make(map[string]string)
+
+		for _, phone := range req.Participants {
+			verified := 0
+			if phone == req.CreatedBy {
+				verified = 1
+			}
+			if _, err := tx.Exec(`INSERT OR IGNORE INTO users(phone_number, verified, notify_by_sms, notify_by_email) VALUES(?, ?, 1, 1)`,
+				phone, verified); err != nil {
+				http.Error(w, "server error", http.StatusInternalServerError)
+				return
+			}
+
+			if phone == req.CreatedBy {
+				// ensure verified flag true if user already existed
+				if _, err := tx.Exec(`UPDATE users SET verified = 1 WHERE phone_number = ?`, phone); err != nil {
+					http.Error(w, "server error", http.StatusInternalServerError)
+					return
+				}
+			}
+
+			if _, err := tx.Exec(`INSERT OR IGNORE INTO group_members(group_id, phone_number) VALUES(?, ?)`,
+				groupID, phone); err != nil {
+				http.Error(w, "server error", http.StatusInternalServerError)
+				return
+			}
+			token := uuid.New().String() // stub token generation
+			inviteLinks[phone] = "https://app.com/invite?token=" + token
+		}
+
+		if err := tx.Commit(); err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(createGroupResponse{
+			GroupID:     groupID,
+			InviteLinks: inviteLinks,
+		})
+	}
+}

--- a/group_create_test.go
+++ b/group_create_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db := initDB(":memory:")
+	return db
+}
+
+func TestCreateGroupEndpoint(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	r := chi.NewRouter()
+	r.Post("/groups/create", createGroupEndpoint(db))
+
+	payload := `{"group_name":"Trip to Berlin","default_currency":"EUR","created_by":"+41791234567","participants":["+41791234567","+49123456789"]}`
+	req := httptest.NewRequest(http.MethodPost, "/groups/create", bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var resp createGroupResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.GroupID == "" {
+		t.Fatalf("expected group_id in response")
+	}
+	if len(resp.InviteLinks) != 2 {
+		t.Fatalf("expected 2 invite links, got %d", len(resp.InviteLinks))
+	}
+
+	// verify group record
+	var name, createdBy, currency string
+	err := db.QueryRow("SELECT name, created_by, default_currency FROM groups WHERE id = ?", resp.GroupID).Scan(&name, &createdBy, &currency)
+	if err != nil {
+		t.Fatalf("query group: %v", err)
+	}
+	if name != "Trip to Berlin" || createdBy != "+41791234567" || currency != "EUR" {
+		t.Fatalf("unexpected group data: %s %s %s", name, createdBy, currency)
+	}
+
+	// verify group members and user verification status
+	phones := []string{"+41791234567", "+49123456789"}
+	for i, phone := range phones {
+		var count int
+		err = db.QueryRow("SELECT COUNT(*) FROM group_members WHERE group_id = ? AND phone_number = ?", resp.GroupID, phone).Scan(&count)
+		if err != nil {
+			t.Fatalf("query member: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("member %d not inserted", i)
+		}
+
+		var verified bool
+		err = db.QueryRow("SELECT verified FROM users WHERE phone_number = ?", phone).Scan(&verified)
+		if err != nil {
+			t.Fatalf("query user: %v", err)
+		}
+		expected := false
+		if phone == "+41791234567" {
+			expected = true
+		}
+		if verified != expected {
+			t.Fatalf("unexpected verified for %s: %v", phone, verified)
+		}
+	}
+}

--- a/groups.go
+++ b/groups.go
@@ -7,8 +7,11 @@ import (
 	"time"
 )
 
-// Group represents a collection of phone numbers.
-type Group struct {
+// LegacyGroup represents the previous group model with inline phone numbers.
+//
+// Deprecated: this type will be removed in favour of `Group` which stores
+// members in a separate table.
+type LegacyGroup struct {
 	ID              int64     `json:"id"`
 	Phones          []string  `json:"phones"`
 	Name            string    `json:"name"`
@@ -25,6 +28,10 @@ type createGroupRequest struct {
 }
 
 // createGroupHandler saves a new group with phone numbers to the database.
+//
+// Deprecated: this handler operates on the old `groups` schema that stored all
+// member phone numbers in a JSON column. New code should use
+// `createGroupEndpoint` instead.
 func createGroupHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req createGroupRequest
@@ -66,7 +73,7 @@ func createGroupHandler(db *sql.DB) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(Group{
+		json.NewEncoder(w).Encode(LegacyGroup{
 			ID:              id,
 			Phones:          req.Phones,
 			Name:            req.Name,

--- a/main.go
+++ b/main.go
@@ -38,7 +38,9 @@ func main() {
 	fileServer := http.FileServer(http.FS(frontendFS))
 	r.Handle("/*", http.StripPrefix("/", fileServer))
 
-	r.Post("/api/groups", createGroupHandler(db))
+	// Deprecated: the /api/groups endpoint used an older schema and has
+	// been replaced by /groups/create.
+	r.Post("/groups/create", createGroupEndpoint(db))
 
 	log.Fatal(http.ListenAndServe(":8080", r))
 }

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS users (
+    phone_number TEXT PRIMARY KEY,
+    verified BOOLEAN NOT NULL DEFAULT 0,
+    display_name TEXT,
+    email TEXT,
+    notify_by_sms BOOLEAN NOT NULL DEFAULT 1,
+    notify_by_email BOOLEAN NOT NULL DEFAULT 1,
+    payment_methods TEXT
+);
+
+CREATE TABLE IF NOT EXISTS groups (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_by TEXT NOT NULL REFERENCES users(phone_number),
+    default_currency TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS group_members (
+    group_id TEXT NOT NULL REFERENCES groups(id),
+    phone_number TEXT NOT NULL REFERENCES users(phone_number),
+    display_name_override TEXT,
+    PRIMARY KEY (group_id, phone_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_members_group_id ON group_members(group_id);
+CREATE INDEX IF NOT EXISTS idx_group_members_phone_number ON group_members(phone_number);

--- a/models.go
+++ b/models.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"database/sql"
+	"time"
+)
+
+// User represents an application user identified by phone number.
+type User struct {
+	PhoneNumber    string         `db:"phone_number" json:"phone_number"`
+	Verified       bool           `db:"verified" json:"verified"`
+	DisplayName    sql.NullString `db:"display_name" json:"display_name"`
+	Email          sql.NullString `db:"email" json:"email"`
+	NotifyBySMS    bool           `db:"notify_by_sms" json:"notify_by_sms"`
+	NotifyByEmail  bool           `db:"notify_by_email" json:"notify_by_email"`
+	PaymentMethods sql.NullString `db:"payment_methods" json:"payment_methods"`
+}
+
+// Group represents a collection of users who share expenses.
+type Group struct {
+	ID              string    `db:"id" json:"id"`
+	Name            string    `db:"name" json:"name"`
+	CreatedBy       string    `db:"created_by" json:"created_by"`
+	DefaultCurrency string    `db:"default_currency" json:"default_currency"`
+	CreatedAt       time.Time `db:"created_at" json:"created_at"`
+}
+
+// GroupMember links a user to a group with optional display name override.
+type GroupMember struct {
+	GroupID             string         `db:"group_id" json:"group_id"`
+	PhoneNumber         string         `db:"phone_number" json:"phone_number"`
+	DisplayNameOverride sql.NullString `db:"display_name_override" json:"display_name_override"`
+}


### PR DESCRIPTION
## Summary
- initialize database tables for users, groups and group_members
- model Go structs for User, Group and GroupMember
- implement POST /groups/create endpoint
- update routes and DB initialization
- deprecate legacy group model

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841c97999048328b43c37d4f15dfd1e