### PR TITLE
Implement invite token using JWT

### DIFF
--- a/group_create.go
+++ b/group_create.go
@@ -71,7 +71,11 @@ func createGroupEndpoint(db *sql.DB) http.HandlerFunc {
 				http.Error(w, "server error", http.StatusInternalServerError)
 				return
 			}
-			token := uuid.New().String() // stub token generation
+			token, err := GenerateInviteToken(phone, groupID)
+			if err != nil {
+				http.Error(w, "server error", http.StatusInternalServerError)
+				return
+			}
 			inviteLinks[phone] = "https://app.com/invite?token=" + token
 		}
 

--- a/group_create_test.go
+++ b/group_create_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -20,6 +21,9 @@ func setupTestDB(t *testing.T) *sql.DB {
 func TestCreateGroupEndpoint(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
+
+	os.Setenv("INVITE_TOKEN_SECRET", "testsecret")
+	defer os.Unsetenv("INVITE_TOKEN_SECRET")
 
 	r := chi.NewRouter()
 	r.Post("/groups/create", createGroupEndpoint(db))

--- a/invite_token.go
+++ b/invite_token.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// InviteClaims represents the payload stored in an invite token.
+type InviteClaims struct {
+	Phone   string `json:"phone"`
+	GroupID string `json:"group_id"`
+	jwt.RegisteredClaims
+}
+
+// GenerateInviteToken creates a signed token granting a phone access to a group.
+// The token expires after 48 hours.
+func GenerateInviteToken(phone string, groupID string) (string, error) {
+	secret := os.Getenv("INVITE_TOKEN_SECRET")
+	if secret == "" {
+		return "", errors.New("INVITE_TOKEN_SECRET not set")
+	}
+	claims := InviteClaims{
+		Phone:   phone,
+		GroupID: groupID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(48 * time.Hour)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}
+
+// ValidateInviteToken parses and validates a previously generated invite token.
+// It returns the claims if the token is valid and not expired.
+func ValidateInviteToken(tokenStr string) (*InviteClaims, error) {
+	secret := os.Getenv("INVITE_TOKEN_SECRET")
+	if secret == "" {
+		return nil, errors.New("INVITE_TOKEN_SECRET not set")
+	}
+
+	parsed, err := jwt.ParseWithClaims(tokenStr, &InviteClaims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(secret), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := parsed.Claims.(*InviteClaims)
+	if !ok || !parsed.Valid {
+		return nil, errors.New("invalid token")
+	}
+	return claims, nil
+}

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGenerateAndValidateInviteToken(t *testing.T) {
+	os.Setenv("INVITE_TOKEN_SECRET", "secret123")
+	defer os.Unsetenv("INVITE_TOKEN_SECRET")
+
+	token, err := GenerateInviteToken("+41791234567", "abc123")
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	claims, err := ValidateInviteToken(token)
+	if err != nil {
+		t.Fatalf("validate token: %v", err)
+	}
+
+	if claims.Phone != "+41791234567" || claims.GroupID != "abc123" {
+		t.Fatalf("unexpected claims: %#v", claims)
+	}
+
+	if time.Until(claims.ExpiresAt.Time) < 47*time.Hour {
+		t.Fatalf("expiry too short: %v", claims.ExpiresAt.Time)
+	}
+}


### PR DESCRIPTION
## Summary
- add JWT-based invite token generation in `invite_token.go`
- use GenerateInviteToken in `createGroupEndpoint`
- set token secret for tests
- test invite token validation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841ef6262a483288fba8a5d1c806b4a